### PR TITLE
Added Shadow HOC, Updated HoverButton styling

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -22,7 +22,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-loaders": "^3.0.1",
-        "react-router-dom": "^6.8.1",
+        "react-router-dom": "^6.9.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -2895,9 +2895,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
-      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==",
       "engines": {
         "node": ">=14"
       }
@@ -12439,11 +12439,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
-      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
       "dependencies": {
-        "@remix-run/router": "1.3.3"
+        "@remix-run/router": "1.4.0"
       },
       "engines": {
         "node": ">=14"
@@ -12453,12 +12453,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
-      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
       "dependencies": {
-        "@remix-run/router": "1.3.3",
-        "react-router": "6.8.2"
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
       },
       "engines": {
         "node": ">=14"
@@ -17254,9 +17254,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
-      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -24071,20 +24071,20 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
-      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
       "requires": {
-        "@remix-run/router": "1.3.3"
+        "@remix-run/router": "1.4.0"
       }
     },
     "react-router-dom": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
-      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
       "requires": {
-        "@remix-run/router": "1.3.3",
-        "react-router": "6.8.2"
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
       }
     },
     "react-scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-loaders": "^3.0.1",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/app/src/components/HoverButton.tsx
+++ b/app/src/components/HoverButton.tsx
@@ -1,31 +1,38 @@
-import React, { useState } from "react";
-
 /*
 A button component that takes in optional props and changes color when
 hovered upon
 
+    *   redirects are best handled with the useNavigate hook from react-router-dom
+
 EXAMPLE USAGE:
     <HoverButton 
-        onClick={event/element}
-        text="henlo"
-        color="rgb(120, 196, 234)"
-        hoverColor="rgb(124, 172, 203)"
+        onClick={event/element}                 //what button should do when clicked
+        text="henlo"                            //text for button
+        color="rgb(120, 196, 234)"              //button's border color
+        hoverColor="rgba(124, 172, 203, 0.2)"   //button's hover color
     />
- */
+*/
 
-interface Props {
+import React, { useState } from "react";
+
+interface HoverButtonProps {
     onClick?: () => void;
     text?: string;
     color?: string;
     hoverColor?: string;
+    link?: string;
 }
 
-const HoverButton: React.FC<Props> = ({ onClick, text, color, hoverColor }) => {
+const HoverButton: React.FC<HoverButtonProps> = ({ onClick, text, color, hoverColor, link }) => {
     const [isHovered, setIsHovered] = useState(false);
 
     const style = {
-        backgroundColor: isHovered && hoverColor ? hoverColor : color || "transparent",
-        border: "none",
+        backgroundColor: isHovered && hoverColor ? hoverColor : "transparent" || "transparent",
+        borderColor: color ? color : 'black' || 'black',
+        width: "100%",
+        height: "100%",
+        padding: "3px 6px",
+        borderRadius: "5px",
     };
 
     const handleClick = () => {
@@ -33,8 +40,8 @@ const HoverButton: React.FC<Props> = ({ onClick, text, color, hoverColor }) => {
     };
 
     return (
-        <div className="HoverButton">
             <button
+                className="hover-button"
                 onClick={onClick ? onClick : handleClick}
                 style={style}
                 onMouseEnter={() => setIsHovered(true)}
@@ -42,7 +49,6 @@ const HoverButton: React.FC<Props> = ({ onClick, text, color, hoverColor }) => {
             >
                 {text}
             </button>
-        </div>
     );
 };
 

--- a/app/src/components/Shadow.tsx
+++ b/app/src/components/Shadow.tsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect, forwardRef } from "react";
+
+interface ShadowProps {
+    shadowColor?: string,
+    shadowOffset?: {x: number; y: number },
+    shadowOpacity?: number,
+    shadowRadius?: number
+}
+
+const shadow = <P extends object>(Component: React.ComponentType<P>, {
+    shadowColor = '#000000',
+    shadowOffset = {x: 0, y: 2},
+    shadowOpacity = 0.2,
+    shadowRadius = 2,
+}: ShadowProps = {}) => {
+    const Shadow: React.FC<P> = (props) => {
+        
+        const shadow = {
+            shadowColor,
+            shadowOffset,
+            shadowOpacity,
+            shadowRadius,
+            elevation: shadowRadius
+        };
+
+        return <Component {...(props as P)} style={[props, shadow]} />;
+    };
+    return Shadow;
+}
+
+export default shadow;

--- a/app/src/components/Shadow.tsx
+++ b/app/src/components/Shadow.tsx
@@ -1,31 +1,46 @@
-import React, { useState, useEffect, forwardRef } from "react";
+/*
+A shadow HOC that takes in optional props and casts a shadow behind a given component
 
-interface ShadowProps {
-    shadowColor?: string,
-    shadowOffset?: {x: number; y: number },
-    shadowOpacity?: number,
-    shadowRadius?: number
+EXAMPLE USAGE:
+    <Shadow>
+        <{component}/>
+    </Shadow>
+*/
+
+import React from "react";
+
+var values = {
+    offsetX: 2,
+    offsetY: 2,
+    blur: 2,
+    spread: 0.25,
+    color: '#5A5A5A',
+    padding: 5,
+    borderRadius: 5,
 }
 
-const shadow = <P extends object>(Component: React.ComponentType<P>, {
-    shadowColor = '#000000',
-    shadowOffset = {x: 0, y: 2},
-    shadowOpacity = 0.2,
-    shadowRadius = 2,
-}: ShadowProps = {}) => {
-    const Shadow: React.FC<P> = (props) => {
-        
-        const shadow = {
-            shadowColor,
-            shadowOffset,
-            shadowOpacity,
-            shadowRadius,
-            elevation: shadowRadius
-        };
-
-        return <Component {...(props as P)} style={[props, shadow]} />;
-    };
-    return Shadow;
+type ShadowProps = {
+    offsetX?: number;
+    offsetY?: number;
+    blur?: number;
+    spread?: number;
+    color?: string;
+    children: React.ReactElement;
+    borderRadius?: number,
 }
 
-export default shadow;
+const Shadow = (props: ShadowProps) => {
+    var shadowStyle = {
+        boxShadow: `${props.offsetX || values.offsetX}px ${props.offsetY || values.offsetY}px ${props.blur || values.blur}px ${props.spread || values.spread}px ${props.color || values.color}`,
+        display: "flex",
+        borderRadius: `${props.borderRadius || values.borderRadius}px`,
+    }
+    
+    return (
+        <div style={shadowStyle}>
+            {props.children}
+        </div>
+    )
+} 
+
+export default Shadow;

--- a/app/src/components/Shadow.tsx
+++ b/app/src/components/Shadow.tsx
@@ -15,7 +15,6 @@ var values = {
     blur: 2,
     spread: 0.25,
     color: '#5A5A5A',
-    padding: 5,
     borderRadius: 5,
 }
 

--- a/app/src/pages/Landing.tsx
+++ b/app/src/pages/Landing.tsx
@@ -1,47 +1,5 @@
-import React, { Component } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
-import shadow from "../components/Shadow";
-import HoverButton from "../components/HoverButton";
-import AboutUs from "./AboutUs";
-
-//const ShadowHoverButton = shadow(HoverButton);
-
-/*function ShadedButton() {
-
-    const addChangeListener = () => {
-        console.log("add change listener!")
-    }
-    const removeChangeListener = () => {
-        console.log("remove change listener!")
-    }
-
-    return class extends Component {
-        constructor(props: any) {
-            super(props);
-            this.handleChange = this.handleChange.bind(this);
-            this.state = {
-                data: selectData(WrappedComponent, props)
-            };
-        }
-
-        componentDidMount() {
-            addChangeListener.bind(this.handleChange);
-        }
-        componentWillUnmount() {
-            removeChangeListener.bind(this.handleChange);
-        }
-
-        handleChange() {
-            this.setState({
-                data: selectData(WrappedComponent, this.props)
-            })
-        }
-
-        render() {
-            return <Component data={this.state} {...this.props} />;
-        }
-    }
-}*/
 
 function Landing() {
     return (

--- a/app/src/pages/Landing.tsx
+++ b/app/src/pages/Landing.tsx
@@ -1,5 +1,48 @@
-import React from "react";
+import React, { Component } from "react";
 import { Link } from "react-router-dom";
+import shadow from "../components/Shadow";
+import HoverButton from "../components/HoverButton";
+import AboutUs from "./AboutUs";
+
+//const ShadowHoverButton = shadow(HoverButton);
+
+/*function ShadedButton() {
+
+    const addChangeListener = () => {
+        console.log("add change listener!")
+    }
+    const removeChangeListener = () => {
+        console.log("remove change listener!")
+    }
+
+    return class extends Component {
+        constructor(props: any) {
+            super(props);
+            this.handleChange = this.handleChange.bind(this);
+            this.state = {
+                data: selectData(WrappedComponent, props)
+            };
+        }
+
+        componentDidMount() {
+            addChangeListener.bind(this.handleChange);
+        }
+        componentWillUnmount() {
+            removeChangeListener.bind(this.handleChange);
+        }
+
+        handleChange() {
+            this.setState({
+                data: selectData(WrappedComponent, this.props)
+            })
+        }
+
+        render() {
+            return <Component data={this.state} {...this.props} />;
+        }
+    }
+}*/
+
 function Landing() {
     return (
         <div className="background">
@@ -21,8 +64,10 @@ function Landing() {
                         </li>
                     </header>
                 </div>
+                
             </div>
             <div className="grid-container">
+                
                 <div className="image-grid">
                     <div className="image">
                         <img src="" alt="" />

--- a/app/src/pages/Opportunities.tsx
+++ b/app/src/pages/Opportunities.tsx
@@ -1,6 +1,10 @@
 import React from "react";
+
 function Opportunities() {
-    return <h1>this is the opportunities page</h1>;
+    return (
+    <div>
+        <h1>this is the opportunities page</h1>
+    </div>)
 }
 
 export default Opportunities;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -100,3 +100,14 @@ h1 {
     border-radius: 10px;
     overflow: hidden;
 }
+
+.shadow-hoc {
+    width: fit-content;
+    height: fit-content;
+}
+
+.hover-button {
+    width: 100%;
+    height: 100%;
+    transition: background-color 0.25s;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3100,6 +3100,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3470,7 +3484,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -5430,6 +5445,13 @@
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
       }
+    },
+    "typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "dev": true,
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",


### PR DESCRIPTION
## Proposed changes

Added a shadow HOC that casts a shadow behind a given component with optional `offsetX`, `offsetY`, `blur`, `spread`, `color`, and `borderRadius` props

HoverButton styling was updated (transition, opacity)

## Related issues

Resolves #13 

## Additional comments

This feature has been tested and should satisfy the corresponding issue.
